### PR TITLE
v0.11.0 - Updating `prepublish` (deprecated) to `prepare` in `package.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.11.0
+------------------------------
+*January 30, 2018*
+
+### Added
+- :bear:
+
+### Changed
+- Updating `prepublish` (deprecated) to `prepare` in `package.json`
+
+
 v0.10.0
 ------------------------------
 *January 29, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-serviceworker",
   "description": "Script for registering the service worker",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "main": "./dist/index.js",
   "files": [
     "dist"
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/justeat/f-serviceworker#readme",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublish": "yarn run compile",
+    "prepare": "yarn run compile",
     "compile": "babel -d dist src"
   },
   "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-﻿# f-serviceworker
+# f-serviceworker :bear:
 
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-serviceworker.svg)](https://badge.fury.io/js/%40justeat%2Ff-serviceworker)
 


### PR DESCRIPTION
### Added
- :bear:

### Changed
- Updating `prepublish` (deprecated) to `prepare` in `package.json`